### PR TITLE
Moved inlinearray_value to infrequent_data structure in MonoClass

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -5254,7 +5254,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 		}
 		if (CHECK_PROTOCOL_VERSION(2, 65)) {
 			if (m_class_is_inlinearray (klass) && nfields == 1)
-				buffer_add_int (buf, m_class_inlinearray_value (klass));
+				buffer_add_int (buf, m_class_inlinearray_value (m_class_get_infrequent_data (klass)));
 			else
 				buffer_add_int (buf, -1);
 		}
@@ -5292,7 +5292,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 			if (CHECK_PROTOCOL_VERSION(2, 65)) {
 				if (m_class_is_inlinearray (klass) && nfields == 1) {
 					int element_size = mono_class_instance_size (mono_class_from_mono_type_internal (f->type)) - MONO_ABI_SIZEOF (MonoObject);
-					int array_size = m_class_inlinearray_value (klass);
+					int array_size = m_class_inlinearray_value (m_class_get_infrequent_data (klass));
 					for (int i = 1; i < array_size; i++)
 						buffer_add_value_full (buf, f->type, ((char*)mono_vtype_get_field_addr (addr, f)) + (i*element_size), domain, FALSE, parent_vtypes, len_fixed_array != 1 ? len_fixed_array : isFixedSizeArray(f));
 				}

--- a/src/mono/mono/metadata/class-getters.h
+++ b/src/mono/mono/metadata/class-getters.h
@@ -30,7 +30,7 @@ MONO_CLASS_GETTER(m_class_was_typebuilder, gboolean, , MonoClass, wastypebuilder
 MONO_CLASS_GETTER(m_class_is_array_special_interface, gboolean, , MonoClass, is_array_special_interface)
 MONO_CLASS_GETTER(m_class_is_byreflike, gboolean, , MonoClass, is_byreflike)
 MONO_CLASS_GETTER(m_class_is_inlinearray, gboolean, , MonoClass, is_inlinearray)
-MONO_CLASS_GETTER(m_class_inlinearray_value, gint32, , MonoClass, inlinearray_value)
+MONO_CLASS_GETTER(m_class_inlinearray_value, gint32, , MonoPropertyBag, inlinearray_value)
 MONO_CLASS_GETTER(m_class_get_min_align, guint8, , MonoClass, min_align)
 MONO_CLASS_GETTER(m_class_get_packing_size, guint, , MonoClass, packing_size)
 MONO_CLASS_GETTER(m_class_is_ghcimpl, gboolean, , MonoClass, ghcimpl)

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -301,7 +301,7 @@ mono_class_setup_fields (MonoClass *klass)
 		instance_size = MONO_ABI_SIZEOF (MonoObject);
 	}
 
-	if (m_class_is_inlinearray (klass) && m_class_inlinearray_value (klass) <= 0) {
+	if (m_class_is_inlinearray (klass) && m_class_inlinearray_value (&klass->infrequent_data) <= 0) {
 		if (mono_get_runtime_callbacks ()->mono_class_set_deferred_type_load_failure_callback)
 			mono_get_runtime_callbacks ()->mono_class_set_deferred_type_load_failure_callback (klass, "Inline array length property must be positive.");
 		else
@@ -735,7 +735,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		attr = class_has_inlinearray_attribute (klass);
 		if (attr.has_attr) {
 			klass->is_inlinearray = 1;
-			klass->inlinearray_value = GPOINTER_TO_INT32 (attr.value);
+			klass->infrequent_data.inlinearray_value = GPOINTER_TO_INT32 (attr.value);
 		}
 	}
 
@@ -940,7 +940,7 @@ mono_class_create_generic_inst (MonoGenericClass *gclass)
 	klass->this_arg.data.generic_class = klass->_byval_arg.data.generic_class = gclass;
 	klass->this_arg.byref__ = TRUE;
 	klass->is_inlinearray = gklass->is_inlinearray;
-	klass->inlinearray_value = gklass->inlinearray_value;
+	klass->infrequent_data.inlinearray_value = gklass->infrequent_data.inlinearray_value;
 	klass->is_exception_class = gklass->is_exception_class;
 	klass->enumtype = gklass->enumtype;
 	klass->valuetype = gklass->valuetype;
@@ -2295,7 +2295,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 					const guint32 struct_max_size = 1024 * 1024;
 					guint32 initial_size = size;
 					// If size overflows, it returns 0
-					size *= m_class_inlinearray_value (klass);
+					size *= m_class_inlinearray_value (&klass->infrequent_data);
 					inlined_fields++;
 					if(size == 0 || size > struct_max_size) {
 						if (mono_get_runtime_callbacks ()->mono_class_set_deferred_type_load_failure_callback) {

--- a/src/mono/mono/metadata/class-private-definition.h
+++ b/src/mono/mono/metadata/class-private-definition.h
@@ -101,7 +101,7 @@ struct _MonoClass {
 	guint16    *interface_offsets_packed;
 	guint8     *interface_bitmap;
 
-	gint32      inlinearray_value; /* System.Runtime.CompilerServices.InlineArrayAttribute length value */
+	
 	guint       name_hash;
 
 	MonoClass **interfaces;

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -5983,7 +5983,7 @@ mono_marshal_load_type_info (MonoClass* klass)
 			// Limit the max size of array instance to 1MiB
 			const int struct_max_size = 1024 * 1024;
 			guint32 initial_size = size;
-			size *= m_class_inlinearray_value (klass);
+			size *= m_class_inlinearray_value (m_class_get_infrequent_data (klass));
 			if(size == 0 || size > struct_max_size) {
 				if (mono_get_runtime_callbacks ()->mono_class_set_deferred_type_load_failure_callback) {
 					if (mono_get_runtime_callbacks ()->mono_class_set_deferred_type_load_failure_callback (klass, "Inline array struct size out of bounds, abnormally large."))
@@ -6815,7 +6815,7 @@ static void record_inlinearray_struct_physical_lowering (guint8* lowered_bytes, 
 	g_assert (field);
 
 	MonoType* fieldType = field->type;
-	for (int i = 0; i < m_class_inlinearray_value(klass); ++i) {
+	for (int i = 0; i < m_class_inlinearray_value(m_class_get_infrequent_data (klass)); ++i) {
 		record_struct_field_physical_lowering(lowered_bytes, fieldType, offset + m_field_get_offset(field) + i * mono_type_size(fieldType, &align) - type_offset);
 	}
 }

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -908,7 +908,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 			guint32 field_instance_offset = field_offset;
 			// If struct has InlineArray attribute, iterate `length` times to set a bitmap
 			if (m_class_is_inlinearray (p))
-				field_iter = m_class_inlinearray_value (p);
+				field_iter = m_class_inlinearray_value (m_class_get_infrequent_data (p));
 
 			if (field_iter > 500)
 				g_warning ("Large number of iterations detected when creating a GC bitmap, might affect performance.");

--- a/src/mono/mono/metadata/property-bag.h
+++ b/src/mono/mono/metadata/property-bag.h
@@ -11,6 +11,7 @@
 #define __MONO_METADATA_PROPERTY_BAG_H__
 
 #include <mono/utils/mono-compiler.h>
+#include <glib.h>
 
 typedef struct _MonoPropertyBagItem MonoPropertyBagItem;
 
@@ -21,6 +22,7 @@ struct _MonoPropertyBagItem {
 
 typedef struct {
 	MonoPropertyBagItem *head;
+	gint32     inlinearray_value;
 } MonoPropertyBag;
 
 void* mono_property_bag_get (MonoPropertyBag *bag, int tag);


### PR DESCRIPTION
# Summary
This PR addresses issue #103913 by moving the `inlinearray_value` property from `MonoClass` to the `infrequent_data` structure. This change aims to optimize memory usage by storing rarely used properties in a less frequently accessed structure.

# Details
- Moved `inlinearray_value` from `MonoClass` to `MonoPropertyBag` within the `infrequent_data` structure.
- Updated relevant getters and setters to reflect the new structure.
- Modified all occurrences of `inlinearray_value` access to use the new structure.
- Performed extensive testing to ensure no functionality is broken due to this change.


# Related Issue
Fixes #103913
